### PR TITLE
Ignore generated build dirs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+__pycache__
+build
+*.egg-info


### PR DESCRIPTION
...unless of course you plan to name this back to spectool in the nearish future.